### PR TITLE
darwin: enable tailscale on mac mini and laptop hosts

### DIFF
--- a/modules/darwin/services/tailscale/default.nix
+++ b/modules/darwin/services/tailscale/default.nix
@@ -1,0 +1,16 @@
+{ lib, config, namespace, ... }:
+let
+  inherit (lib) mkIf;
+  inherit (lib.${namespace}) mkBoolOpt;
+
+  cfg = config.${namespace}.services.tailscale;
+in
+{
+  options.${namespace}.services.tailscale = {
+    enable = mkBoolOpt false "Enable tailscale module";
+  };
+
+  config = mkIf cfg.enable {
+    services.tailscale.enable = true;
+  };
+}

--- a/systems/aarch64-darwin/Q9NPPWVXMF/default.nix
+++ b/systems/aarch64-darwin/Q9NPPWVXMF/default.nix
@@ -21,7 +21,6 @@ in
       skhd = enabled;
       colima = enabled;
       ollama = enabled;
-      tailscale = enabled;
     };
   };
 

--- a/systems/aarch64-darwin/Q9NPPWVXMF/default.nix
+++ b/systems/aarch64-darwin/Q9NPPWVXMF/default.nix
@@ -21,6 +21,7 @@ in
       skhd = enabled;
       colima = enabled;
       ollama = enabled;
+      tailscale = enabled;
     };
   };
 

--- a/systems/aarch64-darwin/olisikh-mini/default.nix
+++ b/systems/aarch64-darwin/olisikh-mini/default.nix
@@ -23,6 +23,7 @@ in
       skhd = enabled;
       colima = enabled;
       ollama = enabled;
+      tailscale = enabled;
     };
   };
 

--- a/systems/aarch64-darwin/olisikhmac/default.nix
+++ b/systems/aarch64-darwin/olisikhmac/default.nix
@@ -23,6 +23,7 @@ in
       skhd = enabled;
       colima = enabled;
       ollama = enabled;
+      tailscale = enabled;
     };
   };
 


### PR DESCRIPTION
## Summary
- add shared nix-darwin tailscale service module at `modules/darwin/services/tailscale/default.nix`
- enable tailscale in all darwin host configs:
  - `systems/aarch64-darwin/olisikh-mini/default.nix`
  - `systems/aarch64-darwin/olisikhmac/default.nix`
  - `systems/aarch64-darwin/Q9NPPWVXMF/default.nix`
- no auth keys/secrets in nix config

## Notes
- This only enables the service declaratively; tailnet login/auth is still done at runtime (`tailscale up`).
- No system apply performed in this task.
